### PR TITLE
Adding script to issue an upload an X.509 V3 certificate to the Key Master

### DIFF
--- a/v3-certificate/README.md
+++ b/v3-certificate/README.md
@@ -1,13 +1,20 @@
-# X.509 V3 Certificate Generator
+# X.509 v3 Certificate Generator
 
-This sample script automatically generates an X.509 V3 Certificate using RSA and uploads it to the [Key Master](https://fusionauth.io/docs/v1/tech/core-concepts/key-master) in your FusionAuth instance.
+This sample script automatically generates an X.509 v3 Certificate using RSA and uploads it to the [Key Master](https://fusionauth.io/docs/v1/tech/core-concepts/key-master) in your FusionAuth instance. You can use this tool when doing integration with other services that require this specific version as the [Key Master](https://fusionauth.io/docs/v1/tech/core-concepts/key-master) uses a different one.
 
-### Usage
+## Prerequisites
 
-Create an [API Key](https://fusionauth.io/docs/v1/tech/apis/authentication#api-key-authentication) in your FusionAuth instance that allows POSTing to `/api/key/import` and run `generate-certificate`.
+- [bash](https://www.gnu.org/software/bash/) to run the script
+- [openssl](https://stedolan.github.io/jq/) to issue certificates
+- [jq](https://www.openssl.org/) to handle JSON objects
 
-It will ask for three values:
-- 
+## Usage
+
+* Create an [API Key](https://fusionauth.io/docs/v1/tech/apis/authentication#api-key-authentication) in your FusionAuth instance that has permission to `POST` to `/api/key/import`.
+* Run `generate-certificate`.
+
+The script will ask for three values:
+
 - `Your FusionAuth instance URL (with scheme)`: the complete address for your instance (e.g. `http://localhost:9011`).
 - `API Key with /api/key/import endpoint`: actual value for the API Key you've created.
 - `Name for the generated key`: a descriptive name for the key. 

--- a/v3-certificate/README.md
+++ b/v3-certificate/README.md
@@ -5,8 +5,8 @@ This sample script automatically generates an X.509 v3 Certificate using RSA and
 ## Prerequisites
 
 - [bash](https://www.gnu.org/software/bash/) to run the script
-- [openssl](https://stedolan.github.io/jq/) to issue certificates
-- [jq](https://www.openssl.org/) to handle JSON objects
+- [openssl](https://www.openssl.org/) to issue certificates
+- [jq](https://stedolan.github.io/jq/) to handle JSON objects
 
 ## Usage
 

--- a/v3-certificate/README.md
+++ b/v3-certificate/README.md
@@ -1,0 +1,15 @@
+# X.509 V3 Certificate Generator
+
+This sample script automatically generates an X.509 V3 Certificate using RSA and uploads it to the [Key Master](https://fusionauth.io/docs/v1/tech/core-concepts/key-master) in your FusionAuth instance.
+
+### Usage
+
+Create an [API Key](https://fusionauth.io/docs/v1/tech/apis/authentication#api-key-authentication) in your FusionAuth instance that allows POSTing to `/api/key/import` and run `generate-certificate`.
+
+It will ask for three values:
+- 
+- `Your FusionAuth instance URL (with scheme)`: the complete address for your instance (e.g. `http://localhost:9011`).
+- `API Key with /api/key/import endpoint`: actual value for the API Key you've created.
+- `Name for the generated key`: a descriptive name for the key. 
+
+After providing the necessary values, it will automatically issue a certificate and upload it to the Key Master in your instance under the name you provided.

--- a/v3-certificate/generate-certificate
+++ b/v3-certificate/generate-certificate
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+#set -e
+
+# Checking openssl
+if [[ -z $(which openssl) ]]; then
+  echo "Please download openssl and make sure it is available in your PATH variable"
+  echo "Homepage: https://www.openssl.org/"
+  exit 1
+fi
+
+# Checking jq
+if [[ -z $(which jq) ]]; then
+  echo "Please download jq and make sure it is available in your PATH variable"
+  echo "jq is used to parse JSON elements"
+  echo "Homepage: https://stedolan.github.io/jq/"
+  exit 1
+fi
+
+# FusionAuth URL
+read -r -p "Your FusionAuth instance URL (with scheme): " FA_URL
+regex='^https?:\/\/[^\/]+(:[0-9]+\/)?$'
+if ! [[ $FA_URL =~ $regex ]]; then
+  echo "FusionAuth URL is not valid. Please make sure you have included the scheme (http:// or https://)."
+  exit 2
+fi
+
+# Extracting domain from URL
+FA_DOMAIN=$(echo "$FA_URL" | awk -F/ '{print $3}')
+if [[ -z "$FA_DOMAIN" ]]; then
+  echo "FusionAuth URL is not valid. Please make sure you have included the scheme (http:// or https://)."
+  exit 2
+fi
+
+# FusionAuth API Key
+read -r -p "API Key with /api/key/import endpoint:      " API_KEY
+API_KEY_LENGTH=${#API_KEY}
+if [ "$API_KEY_LENGTH" -ne 56 ]; then
+  echo "Your API Key seems invalid. Please make sure you copied it correctly."
+  exit 2
+fi
+
+# Key name
+read -r -p "Name for the generated key:                 " NAME
+if [[ -z "$NAME" ]]; then
+  echo "Please provide a valid name for the key."
+  exit 2
+fi
+
+# Creating temporary files for public and private keys
+PRIVATE_KEY_FILE=$(mktemp)
+if [[ -z "$PRIVATE_KEY_FILE" ]]; then
+  echo "Cannot create private key. Please make sure your temporary directory is writable."
+  exit 3
+fi
+PUBLIC_KEY_FILE=$(mktemp)
+if [[ -z "$PUBLIC_KEY_FILE" ]]; then
+  echo "Cannot create public key. Please make sure your temporary directory is writable."
+  exit 3
+fi
+
+# Creating certificate
+RSA_LENGTH=2048
+echo "Generating certificate..."
+if ! openssl req -x509 -newkey "rsa:$RSA_LENGTH" -nodes -keyout "$PRIVATE_KEY_FILE" -out "$PUBLIC_KEY_FILE" -sha256 -days 365 -subj "/CN=$FA_DOMAIN/"; then
+  echo "Error generating certificate. Check messages above for more details."
+  exit 4
+fi
+PUBLIC_KEY=$(cat "$PUBLIC_KEY_FILE")
+PRIVATE_KEY=$(cat "$PRIVATE_KEY_FILE")
+
+# shellcheck disable=SC2016
+JSON_TEMPLATE='{
+  "key": {
+    "algorithm": "RS256",
+    "name": $name,
+    "publicKey": $publicKey,
+    "privateKey": $privateKey,
+    "length": $rsaLength
+  }
+}'
+
+# Uploading keys to the key master
+echo "Uploading to the Key Master..."
+JSON=$(jq --null-input \
+  --arg name "$NAME" \
+  --arg publicKey "$PUBLIC_KEY" \
+  --arg privateKey "$PRIVATE_KEY" \
+  --arg rsaLength "$RSA_LENGTH" \
+  "$JSON_TEMPLATE")
+if ! curl --fail-with-body -s -o /dev/null \
+  -d "$JSON" \
+  -H "Authorization: $API_KEY" \
+  -H "Content-type: application/json" \
+  "$FA_URL/api/key/import"; then
+  echo "Error uploading certificate to the Key Master. Check messages above for more details."
+  exit 5
+fi
+
+echo "Successfuly uploaded key to the Key Master."
+echo "Here is the generated public key:"
+echo "$PUBLIC_KEY"

--- a/v3-certificate/generate-certificate
+++ b/v3-certificate/generate-certificate
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-#set -e
-
 # Checking openssl
 if [[ -z $(which openssl) ]]; then
   echo "Please download openssl and make sure it is available in your PATH variable"
@@ -35,8 +33,8 @@ fi
 # FusionAuth API Key
 read -r -p "API Key with /api/key/import endpoint:      " API_KEY
 API_KEY_LENGTH=${#API_KEY}
-if [ "$API_KEY_LENGTH" -ne 56 ]; then
-  echo "Your API Key seems invalid. Please make sure you copied it correctly."
+if [[ -z "$API_KEY_LENGTH" ]]; then
+  echo "Please provide an API Key."
   exit 2
 fi
 
@@ -62,7 +60,7 @@ fi
 # Creating certificate
 RSA_LENGTH=2048
 echo "Generating certificate..."
-if ! openssl req -x509 -newkey "rsa:$RSA_LENGTH" -nodes -keyout "$PRIVATE_KEY_FILE" -out "$PUBLIC_KEY_FILE" -sha256 -days 365 -subj "/CN=$FA_DOMAIN/"; then
+if ! openssl req -x509 -newkey "rsa:$RSA_LENGTH" -nodes -keyout "$PRIVATE_KEY_FILE" -out "$PUBLIC_KEY_FILE" -sha256 -days 3650 -subj "/CN=$FA_DOMAIN/"; then
   echo "Error generating certificate. Check messages above for more details."
   exit 4
 fi

--- a/v3-certificate/generate-certificate
+++ b/v3-certificate/generate-certificate
@@ -32,8 +32,7 @@ fi
 
 # FusionAuth API Key
 read -r -p "API Key with /api/key/import endpoint:      " API_KEY
-API_KEY_LENGTH=${#API_KEY}
-if [[ -z "$API_KEY_LENGTH" ]]; then
+if [[ -z "$API_KEY" ]]; then
   echo "Please provide an API Key."
   exit 2
 fi


### PR DESCRIPTION
Right now, the Key Master only generates V1 certificates, which certain services (e.g. Aiven) doesn't support when setting up SAML.

I've created a simple script to issue a V3 certificate and upload it to the Key Master.

PS: [here's an article](https://github.com/FusionAuth/fusionauth-site/pull/2085) showing how to integrate FusionAuth and Aiven which mentions this script.