### PR TITLE
docs: add syntax highlighting language

### DIFF
--- a/client-side-password-rules/README.md
+++ b/client-side-password-rules/README.md
@@ -20,7 +20,7 @@ This example shows how to use the `passwordValidationRules` freemarker variables
 
 To use this script, make `FusionAuthPasswordChecker.js` available at a public URL or modify the FusionAuth template files to include this JavaScript on the registration page and change password pages. 
 
-```
+```html
 <script src="https://yourcdn.example.com/path/to/FusionAuthPasswordChecker.js"></script>
 ```
 


### PR DESCRIPTION
missing syntax highlighting in README, finding based on testings for https://github.com/FusionAuth/fusionauth-site/pull/3551

```
10:43:11   ├─ /docs/customize/look-and-feel/client-side-password-rule-validation.html[Shiki] Language "" is not a bundled language. {"url":"https://raw.githubusercontent.com/FusionAuth/fusionauth-example-scripts/main/client-side-password-rules/README.md"}
```